### PR TITLE
Setting share level to 0 immediately when a team dies

### DIFF
--- a/LuaRules/Gadgets/game_communismMode.lua
+++ b/LuaRules/Gadgets/game_communismMode.lua
@@ -24,7 +24,6 @@ local GetTeamInfo               = Spring.GetTeamInfo
 -- Synced Ctrl
 local SetUnitMetalExtraction	= Spring.SetUnitMetalExtraction
 local SetUnitResourcing			= Spring.SetUnitResourcing
-local SetTeamShareLevel         = Spring.SetTeamShareLevel
 local AddTeamResource           = Spring.AddTeamResource
 
 -- constants


### PR DESCRIPTION
Teams automatically share excess command, but when a player resigns, there's a delay until their storage fill up, before they share.
Hence this.
