### PR TITLE
Fixed auto generated units appearing on the build bar

### DIFF
--- a/LuaUI/Widgets/gui_buildbar.lua
+++ b/LuaUI/Widgets/gui_buildbar.lua
@@ -674,7 +674,7 @@ function widget:UnitCreated(unitID, unitDefID, unitTeam)
   end
 
   if UnitDefs[unitDefID].isFactory then
-    push(facs,{ unitID=unitID, unitDefID=unitDefID, buildList=UnitDefs[unitDefID].buildOptions })
+    push(facs,{ unitID=unitID, unitDefID=unitDefID, buildList=GetBuildList(unitDefID)})
   end
   unfinished_facs[unitID] = true
 end


### PR DESCRIPTION
I somehow missed it until playing today...
Will probably put the upgrade commands there some way (note they can't stay, as you can now order 20 upgrades :P)
