### PR TITLE
Fix LoS not resetting after leaving smoke

### DIFF
--- a/LuaRules/Gadgets/unit_smokeshells.lua
+++ b/LuaRules/Gadgets/unit_smokeshells.lua
@@ -166,7 +166,8 @@ function ApplySmoke(unitID)
 	local oldAirLos = GetUnitSensorRadius(unitID, "airLos")
 	local oldSeismic = GetUnitSensorRadius(unitID, "seismic")
 
-	if oldSight > 0 then
+	-- On first round oldLos = 0, check that to avoid overwriting it in later rounds
+	if oldSight > 0 and SmokedUnits[unitID].oldLos == 0 then
 		SmokedUnits[unitID].oldLos = oldSight
 	end
 	if oldRadar > 0 then


### PR DESCRIPTION
Seems change that gave units inside smoke
some LoS broke this as oldSight was not anymore 0.
This caused saved original LoS value to be
overridden with value inside smoke. Added additional
check to avoid overriding.