### PR TITLE
Cook-Torrance specular shader

### DIFF
--- a/ModelMaterials/1_normalmapping.lua
+++ b/ModelMaterials/1_normalmapping.lua
@@ -6,7 +6,7 @@ local SHADER_DIR = "ModelMaterials/Shaders/"
 local materials = {
    normalMappedS3o = {
        shaderDefinitions = {
-	"#define use_perspective_correct_shadows",
+         "#define use_perspective_correct_shadows",
          "#define use_normalmapping",
          --"#define flip_normalmap",
        },
@@ -20,6 +20,23 @@ local materials = {
          [3] = '$specular',
          [4] = '$reflection',
          [5] = '%NORMALTEX',
+       },
+   },
+   normalModelledS3o = {
+       shaderDefinitions = {
+         "#define use_perspective_correct_shadows",
+         --"#define use_normalmapping",
+         --"#define flip_normalmap",
+       },
+       shader    = include(SHADER_DIR .. "default.lua"),
+       usecamera = false,
+       culling   = GL.BACK,
+       texunits  = {
+         [0] = '%%UNITDEFID:0',
+         [1] = '%%UNITDEFID:1',
+         [2] = '$shadow',
+         [3] = '$specular',
+         [4] = '$reflection',
        },
    },
 }
@@ -94,6 +111,8 @@ for i, udef in pairs(UnitDefs) do
       local normaltex = FindNormalmap(tex1,tex2)
       if (normaltex and not unitMaterials[udef.name]) then
         unitMaterials[udef.name] = {"normalMappedS3o", NORMALTEX = normaltex}
+      else
+        unitMaterials[udef.name] = {"normalModelledS3o"}
       end
     end --if model
 
@@ -116,6 +135,8 @@ for i, udef in pairs(UnitDefs) do
           local normaltex = FindNormalmap(tex1,tex2)
           if (normaltex and not unitMaterials[udef.name]) then
             unitMaterials[udef.name] = {"normalMappedS3o", NORMALTEX = normaltex}
+          else
+            unitMaterials[udef.name] = {"normalModelledS3o"}
           end
         end
       end

--- a/ModelMaterials/Shaders/default.lua
+++ b/ModelMaterials/Shaders/default.lua
@@ -193,6 +193,7 @@ vertex = [[
 			outColor.rgb=outColor.rgb*aoTerm;
 		#endif
 
+        outColor.rgb = vec3(1.0);
 		#if (deferred_mode == 0)
 			gl_FragColor = outColor;
 		#else

--- a/ModelMaterials/Shaders/default.lua
+++ b/ModelMaterials/Shaders/default.lua
@@ -193,7 +193,6 @@ vertex = [[
 			outColor.rgb=outColor.rgb*aoTerm;
 		#endif
 
-        outColor.rgb = vec3(1.0);
 		#if (deferred_mode == 0)
 			gl_FragColor = outColor;
 		#else

--- a/ModelMaterials/Shaders/default.lua
+++ b/ModelMaterials/Shaders/default.lua
@@ -104,7 +104,7 @@ vertex = [[
 	uniform vec3 sunAmbient;
 	uniform vec3 etcLoc;
 	#ifndef SPECULARMULT
-		#define SPECULARMULT 2.0
+		#define SPECULARMULT 1.0
 	#endif
 	
 	#ifdef use_shadows
@@ -138,7 +138,45 @@ vertex = [[
 			return 1.0;
 		#endif
 	}
-	
+
+	float beckmannDistribution(float x, float roughness)
+	{
+		float NdotH = max(x, 0.0001);
+		float cos2Alpha = NdotH * NdotH;
+		float tan2Alpha = (cos2Alpha - 1.0) / cos2Alpha;
+		float roughness2 = roughness * roughness;
+		float denom = 3.141592653589793 * roughness2 * cos2Alpha * cos2Alpha;
+		return exp(tan2Alpha / roughness2) / denom;
+	}
+
+	float cookTorranceSpecular(vec3 lightDirection,
+	                           vec3 viewDirection,
+	                           vec3 surfaceNormal,
+	                           float roughness,
+	                           float fresnel)
+	{
+		float VdotN = max(dot(viewDirection, surfaceNormal), 0.0);
+		float LdotN = max(dot(lightDirection, surfaceNormal), 0.0);
+
+		//Half angle vector
+		vec3 H = normalize(lightDirection + viewDirection);
+
+		//Geometric term
+		float NdotH = max(dot(surfaceNormal, H), 0.0);
+		float VdotH = max(dot(viewDirection, H), 0.000001);
+		float x = 2.0 * NdotH / VdotH;
+		float G = min(1.0, min(x * VdotN, x * LdotN));
+
+		//Distribution term
+		float D = beckmannDistribution(NdotH, roughness);
+
+		//Fresnel term
+		float F = pow(1.0 - VdotN, fresnel);
+
+		//Multiply terms and done
+		return  G * F * D / max(3.14159265 * VdotN * LdotN, 0.000001);
+	}
+
 	void main(void){
 		%%FRAGMENT_PRE_SHADING%%
 
@@ -161,7 +199,13 @@ vertex = [[
 		vec3 reflectDir = reflect(cameraDir, normal);
 		
 		#if (deferred_mode == 0)
-			vec3 specular   = textureCube(specularTex, reflectDir).rgb * extraColor.g * SPECULARMULT;
+			// vec3 specular   = textureCube(specularTex, reflectDir).rgb * extraColor.g * SPECULARMULT;
+			float CTS = cookTorranceSpecular(sunPos,
+			                                 -normalize(cameraDir),
+			                                 normal,
+			                                 1.0 - extraColor.g,
+			                                 0.8);
+			vec3 specular   = sunDiffuse * CTS * SPECULARMULT;
 			vec3 reflection = textureCube(reflectTex,  reflectDir).rgb;
 		#endif
 		#if (deferred_mode == 1) 


### PR DESCRIPTION
A much more physically correct specular shader.
For the time being, it is applied to all the units. We may consider extending it also to the features (in the future)