### PR TITLE
Fixing SSAO when deferred is not enabled

### DIFF
--- a/LuaUI/Widgets/gfx_ssao.lua
+++ b/LuaUI/Widgets/gfx_ssao.lua
@@ -132,6 +132,14 @@ function widget:Initialize()
 		return
 	end
 
+	if (Spring.GetConfigInt("AllowDeferredMapRendering") == 0 or Spring.GetConfigInt("AllowDeferredModelRendering") == 0) then
+		Spring.Echo('SSAO (gfx_ssao.lua) requires restarting Spring to properly work!') 
+		Spring.SetConfigInt("AllowDeferredMapRendering", 1)
+		Spring.SetConfigInt("AllowDeferredModelRendering", 1)
+		widgetHandler:RemoveWidget()
+		return
+	end
+
 	-- The Noise texture generation shader, called just once
 	-- =====================================================
 	noiseShader = noiseShader or glCreateShader({


### PR DESCRIPTION
SSAO requires AllowDeferredMapRendering and AllowDeferredModelRendering, but they are disabled in some platforms (I don't know why)
Since enabling it when the game has started is useless, what I'm doing is setting it, but disabling the widget anyway, reporting that Spring should be restarted to get it properly working