### PR TITLE
tweaking the prone hitspheres changes + fixing infantry guns spheres …

### DIFF
--- a/BaseClasses/Units/Infantry.lua
+++ b/BaseClasses/Units/Infantry.lua
@@ -33,6 +33,7 @@ local Infantry = Unit:New{
 		damageGroup			= "infantry",
 		feartarget			= true,
 		soundcategory 		= "<SIDE>/Infantry",
+		pronespheremovemult = 0.4,
 		wiki_parser                 = "infantry",  -- infantry.md template
 		wiki_subclass_comments      = "",      -- To be override by inf classes
 		wiki_comments               = "",      -- To be override by each unit
@@ -349,6 +350,7 @@ local InfantryGun = Infantry:New{
 		hasturnbutton		= true,
 		maxammo				= 4,
 		infgun				= true,
+		pronespheremovemult = 0.2,
 		scriptAnimation = "infantrygun_anim",
 		wiki_subclass_comments = [[This gun, towed by infantry, is an efficient
 way to provide infantry support, becoming relatively cheap, with a long enough

--- a/LuaRules/Gadgets/game_fearHandler.lua
+++ b/LuaRules/Gadgets/game_fearHandler.lua
@@ -26,6 +26,7 @@ local GetTeamInfo				= Spring.GetTeamInfo
 local CallCOBScript				= Spring.CallCOBScript
 local SetUnitExperience			= Spring.SetUnitExperience
 local SetUnitRulesParam 		= Spring.SetUnitRulesParam
+
 -- constants
 local MORALE_RADIUS = 150
 local FEAR_IDS = 	{["301"] = 2, --small arms or very small calibre cannon: MGs, snipers, LMGs, 20mm
@@ -34,6 +35,8 @@ local FEAR_IDS = 	{["301"] = 2, --small arms or very small calibre cannon: MGs, 
 					 ["601"] = 16, --omgwtfbbq explosions: medium/large bombs, 170+mm guns, rocket arty}
 					 ["701"] = 2  --a hack for aircraft fear, should be merged with 301 at some point.
 					}
+local DEFAULT_PRONE_SPHERE_MOVE_MULT = 0.4
+
 -- variables
 local cobScriptIDs = {}
 local lusScriptIDs = {}
@@ -55,15 +58,16 @@ if (gadgetHandler:IsSyncedCode()) then
 local function UpdateCollision(unitID, direction)
 	local unitDef = UnitDefs[Spring.GetUnitDefID(unitID)]
 	
-	-- filter out static units like MG nests and AA posts
+	-- filter out static units like MG nests and AA/AT posts
 	if (unitDef.speed > 0) then
 		
 		-- filter out repeated calls on units already in proper state
 		if ((collisionUpdated[unitID] and direction == 1) or (collisionUpdated[unitID] == nil and direction == -1)) then
+			local sphereMult = unitDef.customParams.pronespheremovemult or DEFAULT_PRONE_SPHERE_MOVE_MULT
 			
 			-- hitsphere update 
 			local scaleX, scaleY, scaleZ, offsetX, offsetY, offsetZ, volumeType, testType, primaryAxis = Spring.GetUnitCollisionVolumeData(unitID)
-			Spring.SetUnitCollisionVolumeData(unitID, scaleX, scaleY, scaleZ, offsetX, offsetY + direction * scaleY/2, offsetZ, volumeType, testType, primaryAxis)
+			Spring.SetUnitCollisionVolumeData(unitID, scaleX, scaleY, scaleZ, offsetX, offsetY + direction * scaleY * sphereMult, offsetZ, volumeType, testType, primaryAxis)
 			
 			-- ! it is not possible to play with the aim pos because it setting mid pos via Spring.SetUnitMidAndAimPos will reset the animation script
 			-- enemies aiming to old position will still hit

--- a/units/gbr/infantry/GBRInfantry.lua
+++ b/units/gbr/infantry/GBRInfantry.lua
@@ -117,6 +117,7 @@ local GBR_Commando = SMGInf:New(GBRInf):New{
 		weaponcost			= 50,
 		weaponswithammo		= 0,	-- do not remove, needed to prevent sten and grenade from using ammo!
 		flagcaprate			= 0,
+		pronespheremovemult = 0.5,
 	},
 	weapons = {
 		[1] = { -- SMG

--- a/units/ita/infantry/ITAInfantry.lua
+++ b/units/ita/infantry/ITAInfantry.lua
@@ -7,6 +7,9 @@ local ITAInf = {
 local Alpini = {
 	maxDamageMul		= 1.25,
 	movementClass		= "KBOT_alpini",
+	customParams = {
+		pronespheremovemult = 0.5,
+	}
 }
 local Bersaglieri = {
 	maxDamageMul		= 1.15,

--- a/units/jpn/infantry/JPNInfantry.lua
+++ b/units/jpn/infantry/JPNInfantry.lua
@@ -1,7 +1,7 @@
 local JPNInf = {
 	maxDamageMul		= 0.94,
 	customParams = {
-
+		pronespheremovemult = 0.5,
 	},
 }
 

--- a/units/swe/infantry/SWEInfantry.lua
+++ b/units/swe/infantry/SWEInfantry.lua
@@ -79,6 +79,9 @@ local SWE_Sniper = SniperInf:New(SWEInf):New{
 			name				= "Gevar_M_38_Sniper",
 		},
 	},
+	customParams = {
+		pronespheremovemult = 0.5,
+	}
 }
 
 local SWE_PSkottM45 = ATLauncherInf:New(SWEInf):New{
@@ -137,6 +140,7 @@ local SWE_Partisan = RifleInf:New(Partisan):New{
 	customParams = {
 		flagCapRate			= 0.005,
 		weapontoggle		= "ambush",
+		pronespheremovemult = 0.5,
 	},
 
 	weapons = {

--- a/units/us/infantry/USInfantry.lua
+++ b/units/us/infantry/USInfantry.lua
@@ -8,7 +8,7 @@ local USInf = {
 local USPara = {
 	maxDamageMul		= 1.4,
 	customParams = {
-
+		pronespheremovemult = 0.5,
 	},
 }
 

--- a/units/us/infantry/USParatrooper.lua
+++ b/units/us/infantry/USParatrooper.lua
@@ -5,7 +5,7 @@ local USParatrooper = Null:New{
 	objectName					= "US/USParatrooper.s3o",
 	customParams = {
 		damageGroup			= "infantry",
-
+		pronespheremovemult = 0.5,
 	},
 }
 


### PR DESCRIPTION
…[https://trello.com/c/SrskfX28/]

* before all inf units moving sphere down by 0.5 of its size
* now :
** defined by customParams
** infantry default is 0.4
** GBR commando, US paratroopers, SWE sniper and partisans, all JAP infantry, ITA alpini have 0.5
** infantry support guns have all 0.2 (due fact middle of their sphere is already on the ground by default)