### PR TITLE
fixed price for support vehicles without MGs

### DIFF
--- a/units/hun/vehicles/HUN40MNimrod.lua
+++ b/units/hun/vehicles/HUN40MNimrod.lua
@@ -30,7 +30,7 @@ local HUN40MNimrod = ArmouredCarAA:New{
 
 local HUN43MLehel = HalfTrack:New{
 	name					= "43.M Lehel",
-	buildCostMetal			= 1100,
+	buildCostMetal			= 900,
 	corpse				= "HUN43MLehel_Abandoned",
 	maxDamage				= 1020,
 	trackOffset				= 10,

--- a/units/jpn/vehicles/JPNHoHa.lua
+++ b/units/jpn/vehicles/JPNHoHa.lua
@@ -1,6 +1,6 @@
 local JPNHoHa = HalfTrack:New{
 	name					= "Type 1 Ho-Ha",
-	buildCostMetal			= 1100,
+	buildCostMetal			= 700,
 	maxDamage				= 900,
 	trackOffset				= 10,
 	trackWidth				= 15,

--- a/units/swe/vehicles/SWETgBilM42.lua
+++ b/units/swe/vehicles/SWETgBilM42.lua
@@ -1,7 +1,7 @@
 local SWETgBilM42 = HalfTrack:New{
 	name					= "Terrängbil m/42 KP",
 	description				= "Transport/Supply Armoured Truck",
-	buildCostMetal			= 1100,
+	buildCostMetal			= 800,
 	maxDamage				= 646,
 	trackOffset				= 10,
 	trackWidth				= 15,


### PR DESCRIPTION
This balances the price better for the support vehicles without MGs.
Japan has the lowest because of less armour + less structure points.
Then comes SWE with better armour and then hun with best structure points + best armour.

Signed-off-by: Christian Rebischke <chris@nullday.de>