### PR TITLE
Further fixes in spring 104

### DIFF
--- a/LuaRules/Gadgets/lus_helper.lua
+++ b/LuaRules/Gadgets/lus_helper.lua
@@ -419,7 +419,7 @@ function GG.ApplySpeedChanges(unitID)
 				if cmds[2] and cmds[2].id == CMD.SET_WANTED_MAX_SPEED then
 					GiveOrderToUnit(unitID,CMD.REMOVE,{cmds[2].tag},{})
 				end
-				local params = {1, CMD.SET_WANTED_MAX_SPEED, 0, newSpeed}
+				local params = {1, CMD.SET_WANTED_MAX_SPEED or cmds[1].id, 0, newSpeed}
 				SetGroundMoveTypeData(unitID, {maxSpeed = newSpeed, maxReverseSpeed = newReverseSpeed})
 				GiveOrderToUnit(unitID, CMD.INSERT, params, {"alt"})
 			end

--- a/LuaRules/Gadgets/unit_targetPriorities.lua
+++ b/LuaRules/Gadgets/unit_targetPriorities.lua
@@ -26,8 +26,13 @@ local unitDefIDsPassed = {}
 	-- return false
 -- end
 
+function ValidID(objectID)
+	return Spring.ValidUnitID(objectID) or Spring.ValidFeatureID(objectID)
+end
+
 function gadget:AllowWeaponTarget(unitID, targetID, attackerWeaponNum, attackerWeaponDefID, defPriority)
-	if lusPriorityCache[unitID] then
+	-- Apparently, in spring-104 the targetID can be an invalid ID
+	if lusPriorityCache[unitID] and ValidID(targetID) then
 		local newPriority = Spring.UnitScript.CallAsUnit(unitID, lusPriorityCache[unitID], targetID, attackerWeaponNum, attackerWeaponDefID, defPriority)
 		return true, newPriority
 	else

--- a/LuaUI/Widgets/cmd_keep_target.lua
+++ b/LuaUI/Widgets/cmd_keep_target.lua
@@ -19,7 +19,7 @@ Spring.Echo("CMDIDs in keeptarget:", CMD_UNIT_SET_TARGET, CMD_UNIT_CANCEL_TARGET
 
 function widget:CommandNotify(id, params, options)
     if id == CMD.SET_WANTED_MAX_SPEED then
-        return false -- FUCK CMD.SET_WANTED_MAX_SPEED
+        return false -- FUCK CMD.SET_WANTED_MAX_SPEED (In spring 104 this cannot happens)
     end
     if id == CMD.MOVE then
         local units = Spring.GetSelectedUnits()

--- a/LuaUI/Widgets/unit_customformations2.lua
+++ b/LuaUI/Widgets/unit_customformations2.lua
@@ -150,7 +150,7 @@ local CMD_MOVE = CMD.MOVE
 local CMD_ATTACK = CMD.ATTACK
 local CMD_UNLOADUNIT = CMD.UNLOAD_UNIT
 local CMD_UNLOADUNITS = CMD.UNLOAD_UNITS
-local CMD_SET_WANTED_MAX_SPEED = CMD.SET_WANTED_MAX_SPEED
+local CMD_SET_WANTED_MAX_SPEED = CMD.SET_WANTED_MAX_SPEED  -- Removed in spring 104
 local CMD_OPT_ALT = CMD.OPT_ALT
 local CMD_OPT_CTRL = CMD.OPT_CTRL
 local CMD_OPT_META = CMD.OPT_META
@@ -566,24 +566,26 @@ function widget:MouseRelease(mx, my, mButton)
 				end
 			end
 		end
-		
-		-- Move Speed (Applicable to every order)
-		local wantedSpeed = 99999 -- High enough to exceed all units speed, but not high enough to cause errors (i.e. vs math.huge)
-		
-		if ctrl then
-			local selUnits = spGetSelectedUnits()
-			for i = 1, #selUnits do
-				local uSpeed = UnitDefs[spGetUnitDefID(selUnits[i])].speed
-				if uSpeed > 0 and uSpeed < wantedSpeed then
-					wantedSpeed = uSpeed
+
+		if CMD_SET_WANTED_MAX_SPEED then  -- Removed in spring 104
+			-- Move Speed (Applicable to every order)
+			local wantedSpeed = 99999 -- High enough to exceed all units speed, but not high enough to cause errors (i.e. vs math.huge)
+			
+			if ctrl then
+				local selUnits = spGetSelectedUnits()
+				for i = 1, #selUnits do
+					local uSpeed = UnitDefs[spGetUnitDefID(selUnits[i])].speed
+					if uSpeed > 0 and uSpeed < wantedSpeed then
+						wantedSpeed = uSpeed
+					end
 				end
 			end
+			
+			-- Directly giving speed order appears to work perfectly, including with shifted orders ...
+			-- ... But other widgets CMD.INSERT the speed order into the front (Posn 1) of the queue instead (which doesn't work with shifted orders)
+			local speedOpts = GetCmdOpts(alt, ctrl, meta, shift, true)
+			GiveNotifyingOrder(CMD_SET_WANTED_MAX_SPEED, {wantedSpeed / 30}, speedOpts)
 		end
-		
-		-- Directly giving speed order appears to work perfectly, including with shifted orders ...
-		-- ... But other widgets CMD.INSERT the speed order into the front (Posn 1) of the queue instead (which doesn't work with shifted orders)
-		local speedOpts = GetCmdOpts(alt, ctrl, meta, shift, true)
-		GiveNotifyingOrder(CMD_SET_WANTED_MAX_SPEED, {wantedSpeed / 30}, speedOpts)
 	end
 	
 	if #fNodes > 1 then


### PR DESCRIPTION
2 changes to addapt the game to the new engine versions:

* It seems that spring can now call `AllowWeaponTarget` with an invalid targetID
* CMD.SET_WANTED_MAX_SPEED has been removed

I hereby removed the possibility to move the units together with a common velocity. Recovering that shall be done in the LUA stuff (a bit risky since  LuaRules/Gadgets/lus_helper.lua is already tweaking the max speed).