### PR TITLE
Fixed [string "luagadgets/gadgets.lua"]:1337: bad argument #2 to "max…

### DIFF
--- a/LuaRules/Gadgets/unit_targetPriorities.lua
+++ b/LuaRules/Gadgets/unit_targetPriorities.lua
@@ -31,13 +31,14 @@ function ValidID(objectID)
 end
 
 function gadget:AllowWeaponTarget(unitID, targetID, attackerWeaponNum, attackerWeaponDefID, defPriority)
+	-- Apparently, in spring-104 defPriority can be nil
+	defPriority = defPriority or 0.0
 	-- Apparently, in spring-104 the targetID can be an invalid ID
 	if lusPriorityCache[unitID] and ValidID(targetID) then
 		local newPriority = Spring.UnitScript.CallAsUnit(unitID, lusPriorityCache[unitID], targetID, attackerWeaponNum, attackerWeaponDefID, defPriority)
 		return true, newPriority
-	else
-		return true, defPriority
 	end
+	return true, defPriority
 end
 
 function gadget:UnitCreated(unitID, unitDefID)


### PR DESCRIPTION
Fix for the following error (104-maintenance):

[Game::ClientReadNet][LOGMSG] sender="Player" string="[Internal Lua error: Call failure] [string "luagadgets/gadgets.lua"]:1337: bad argument #2 to 'max' (number expected, got nil)
stack traceback:
        [C]: in function 'max'
        [string "luagadgets/gadgets.lua"]:1337: in function <[string "luagadgets/gadgets.lua"]:1326>
        (tail call): ?"