### PR TITLE
Fixed problems caused by CMD.SET_WANTED_MAX_SPEED command removal

### DIFF
--- a/LuaRules/Gadgets/0_api_customCmdHandler.lua
+++ b/LuaRules/Gadgets/0_api_customCmdHandler.lua
@@ -14,15 +14,15 @@ end
 -- The filename of this file starts with a 0 to ensure that it is loaded before all other gadgets
 -- Note that loading order != execution order, which is what layer in GetInfo controls!
 
--- Setup
-GG.CustomCommands = {}
-GG.CustomCommands.numCmds = 0
-GG.CustomCommands.IDs = {}
-
-_G.CustomCommandIDs = {}
-
 -- Constants
 local BASE_CMD_ID = 1001
+
+-- Setup (add the commands that shall have a fixed ID here, e.g. all of those
+-- that are called in widgets, and therefore cannot call GG)
+GG.CustomCommands = {}
+GG.CustomCommands.numCmds = 1
+GG.CustomCommands.IDs = {CMD_SET_WANTED_MAX_SPEED = BASE_CMD_ID + 1}
+_G.CustomCommandIDs = {CMD_SET_WANTED_MAX_SPEED = BASE_CMD_ID + 1}
 
 -- Variables
 local customCommands = GG.CustomCommands

--- a/LuaRules/Gadgets/cmd_wanted_speed.lua
+++ b/LuaRules/Gadgets/cmd_wanted_speed.lua
@@ -54,7 +54,7 @@ end
 
 function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
     if cmdID ~= CMD_SET_WANTED_MAX_SPEED then
-        MaintainWantedSpeed(unitID)
+        -- MaintainWantedSpeed(unitID)  -- Zero-K has this enabled for some reason
         return true
     end
 

--- a/LuaRules/Gadgets/cmd_wanted_speed.lua
+++ b/LuaRules/Gadgets/cmd_wanted_speed.lua
@@ -1,0 +1,80 @@
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+if not gadgetHandler:IsSyncedCode() then
+    return
+end
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+function gadget:GetInfo()
+    return {
+        name      = "Wanted Speed",
+        desc      = "Adds a command which sets maxWantedSpeed.",
+        author    = "GoogleFrog",
+        date      = "11 November 2018",
+        license   = "GNU GPL, v2 or later",
+        layer     = -math.huge + 1, -- Right after 0_api_customCmdHandler.lua
+        enabled   = not CMD.SET_WANTED_MAX_SPEED
+    }
+end
+
+-------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------
+
+local CMD_SET_WANTED_MAX_SPEED = GG.CustomCommands.GetCmdID("CMD_SET_WANTED_MAX_SPEED")
+local lastWantedSpeed = {}
+
+-------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------
+
+local function SetUnitWantedSpeed(unitID, wantedSpeed, forceUpdate)
+    if (not forceUpdate) and (lastWantedSpeed[unitID] == wantedSpeed) then
+        return
+    end
+
+    lastWantedSpeed[unitID] = wantedSpeed
+    Spring.MoveCtrl.SetGroundMoveTypeData(unitID, "maxWantedSpeed", (wantedSpeed or 2000))
+end
+
+function GG.ForceUpdateWantedMaxSpeed(unitID)
+    SetUnitWantedSpeed(unitID, lastWantedSpeed[unitID], true)
+end
+
+local function MaintainWantedSpeed(unitID)
+    if not lastWantedSpeed[unitID] then
+        return
+    end
+    
+    Spring.MoveCtrl.SetGroundMoveTypeData(unitID, "maxWantedSpeed", lastWantedSpeed[unitID])
+end
+
+-------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------
+-- Command Handling
+
+function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions)
+    if cmdID ~= CMD_SET_WANTED_MAX_SPEED then
+        MaintainWantedSpeed(unitID)
+        return true
+    end
+
+    local wantedSpeed = cmdParams[1]
+    if not wantedSpeed then
+        return false
+    end
+    wantedSpeed = (wantedSpeed > 0) and wantedSpeed
+    SetUnitWantedSpeed(unitID, wantedSpeed)
+
+    return false
+end
+
+-------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------
+-- Cleanup
+
+function gadget:UnitDestroyed(unitID)
+    lastWantedSpeed[unitID] = nil
+end
+
+-------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------

--- a/LuaRules/Gadgets/craig/pathfinder.lua
+++ b/LuaRules/Gadgets/craig/pathfinder.lua
@@ -158,17 +158,18 @@ local GetUnitDefID = Spring.GetUnitDefID
 
 
 local function DoGiveOrdersToUnit(previous, target, unitID, cmd, minMaxSpeed, spread)
+	local CMD_SET_WANTED_MAX_SPEED = CMD.SET_WANTED_MAX_SPEED or GG.CustomCommands.GetCmdID("CMD_SET_WANTED_MAX_SPEED")
 	if spread then
 		local dx = math.random() * spread * 2 - spread
 		local dz = math.random() * spread * 2 - spread
 		for _,p in PathFinder.PathIterator(previous, target) do
 			GiveOrderToUnit(unitID, cmd, {p.x + dx, p.y, p.z + dz}, options)
-			--GiveOrderToUnit(unitID, CMD.SET_WANTED_MAX_SPEED, {minMaxSpeed}, options)
+			GiveOrderToUnit(unitID, CMD_SET_WANTED_MAX_SPEED, {minMaxSpeed}, options)
 		end
 	else
 		for _,p in PathFinder.PathIterator(previous, target) do
 			GiveOrderToUnit(unitID, cmd, {p.x, p.y, p.z}, options)
-			--GiveOrderToUnit(unitID, CMD.SET_WANTED_MAX_SPEED, {minMaxSpeed}, options)
+			GiveOrderToUnit(unitID, CMD_SET_WANTED_MAX_SPEED, {minMaxSpeed}, options)
 		end
 	end
 end

--- a/LuaRules/Gadgets/lus_helper.lua
+++ b/LuaRules/Gadgets/lus_helper.lua
@@ -38,6 +38,7 @@ local CallAsUnit 			= Spring.UnitScript.CallAsUnit
 -- Unsynced Ctrl
 -- Constants
 local RANGE_INACCURACY_PERCENT = 5
+local CMD_SET_WANTED_MAX_SPEED = CMD.SET_WANTED_MAX_SPEED or GG.CustomCommands.GetCmdID("CMD_SET_WANTED_MAX_SPEED")
 -- Variables
 
 -- Useful functions for GG
@@ -416,10 +417,10 @@ function GG.ApplySpeedChanges(unitID)
 		--if #cmds >= 2 then
 		if #cmds >= 1 then
 			if cmds[1].id == CMD.MOVE or cmds[1].id == CMD.FIGHT or cmds[1].id == CMD.ATTACK then
-				if cmds[2] and cmds[2].id == CMD.SET_WANTED_MAX_SPEED then
-					GiveOrderToUnit(unitID,CMD.REMOVE,{cmds[2].tag},{})
+				if cmds[2] and cmds[2].id == CMD_SET_WANTED_MAX_SPEED then
+					GiveOrderToUnit(unitID, CMD.REMOVE, {cmds[2].tag}, {})
 				end
-				local params = {1, CMD.SET_WANTED_MAX_SPEED or cmds[1].id, 0, newSpeed}
+				local params = {1, CMD_SET_WANTED_MAX_SPEED, 0, newSpeed}
 				SetGroundMoveTypeData(unitID, {maxSpeed = newSpeed, maxReverseSpeed = newReverseSpeed})
 				GiveOrderToUnit(unitID, CMD.INSERT, params, {"alt"})
 			end

--- a/LuaUI/Widgets/cmd_doubleclickfight.lua
+++ b/LuaUI/Widgets/cmd_doubleclickfight.lua
@@ -32,7 +32,7 @@ local CMD_OPT_CTRL  = CMD.OPT_CTRL
 local CMD_OPT_RIGHT = CMD.OPT_RIGHT
 local CMD_OPT_SHIFT = CMD.OPT_SHIFT
 local CMD_REMOVE    = CMD.REMOVE
-local CMD_SET_WANTED_MAX_SPEED = CMD.SET_WANTED_MAX_SPEED
+local CMD_SET_WANTED_MAX_SPEED = CMD.SET_WANTED_MAX_SPEED or 1002  -- See LuaRules/Gadgets/unit_customformations2.lua
 
 local spDiffTimers           = Spring.DiffTimers
 local spGetCommandQueue      = Spring.GetCommandQueue

--- a/LuaUI/Widgets/cmd_keep_target.lua
+++ b/LuaUI/Widgets/cmd_keep_target.lua
@@ -14,12 +14,13 @@ local GetGameRulesParam = Spring.GetGameRulesParam
 
 local CMD_UNIT_SET_TARGET = GetGameRulesParam("CMD_UNIT_SET_TARGET")
 local CMD_UNIT_CANCEL_TARGET = GetGameRulesParam("CMD_UNIT_CANCEL_TARGET")
+local CMD_SET_WANTED_MAX_SPEED = CMD.SET_WANTED_MAX_SPEED or 1002  -- See LuaRules/Gadgets/unit_customformations2.lua
 
 Spring.Echo("CMDIDs in keeptarget:", CMD_UNIT_SET_TARGET, CMD_UNIT_CANCEL_TARGET)
 
 function widget:CommandNotify(id, params, options)
-    if id == CMD.SET_WANTED_MAX_SPEED then
-        return false -- FUCK CMD.SET_WANTED_MAX_SPEED (In spring 104 this cannot happens)
+    if id == CMD_SET_WANTED_MAX_SPEED then
+        return false -- FUCK CMD.SET_WANTED_MAX_SPEED
     end
     if id == CMD.MOVE then
         local units = Spring.GetSelectedUnits()

--- a/LuaUI/Widgets/unit_customformations2.lua
+++ b/LuaUI/Widgets/unit_customformations2.lua
@@ -150,12 +150,14 @@ local CMD_MOVE = CMD.MOVE
 local CMD_ATTACK = CMD.ATTACK
 local CMD_UNLOADUNIT = CMD.UNLOAD_UNIT
 local CMD_UNLOADUNITS = CMD.UNLOAD_UNITS
-local CMD_SET_WANTED_MAX_SPEED = CMD.SET_WANTED_MAX_SPEED  -- Removed in spring 104
+local CMD_SET_WANTED_MAX_SPEED = CMD.SET_WANTED_MAX_SPEED or 1002  -- See LuaRules/Gadgets/unit_customformations2.lua
 local CMD_OPT_ALT = CMD.OPT_ALT
 local CMD_OPT_CTRL = CMD.OPT_CTRL
 local CMD_OPT_META = CMD.OPT_META
 local CMD_OPT_SHIFT = CMD.OPT_SHIFT
 local CMD_OPT_RIGHT = CMD.OPT_RIGHT
+
+local REMOVED_SET_WANTED_MAX_SPEED = not CMD.SET_WANTED_MAX_SPEED
 
 local keyShift = 304
 
@@ -338,6 +340,33 @@ local function GiveNotifyingOrderToUnit(uID, cmdID, cmdParams, cmdOpts)
 		end
 	end
 	spGiveOrderToUnit(uID, cmdID, cmdParams, cmdOpts.coded)
+end
+
+local function SendSetWantedMaxSpeed(alt, ctrl, meta, shift)
+	-- Move Speed (Applicable to every order)
+	local wantedSpeed = 99999 -- High enough to exceed all units speed, but not high enough to cause errors (i.e. vs math.huge)
+	if ctrl then
+		local selUnits = spGetSelectedUnits()
+		for i = 1, #selUnits do
+			local ud = UnitDefs[spGetUnitDefID(selUnits[i])]
+			local uSpeed = ud and ud.speed
+			if uSpeed and uSpeed > 0 and uSpeed < wantedSpeed then
+				wantedSpeed = uSpeed
+			end
+		end
+	elseif REMOVED_SET_WANTED_MAX_SPEED then
+		wantedSpeed = -1
+	end
+	
+	-- Directly giving speed order appears to work perfectly, including with shifted orders ...
+	-- ... But other widgets CMD.INSERT the speed order into the front (Posn 1) of the queue instead (which doesn't work with shifted orders)
+	if REMOVED_SET_WANTED_MAX_SPEED then
+		local units = Spring.GetSelectedUnits()
+		Spring.GiveOrderToUnitArray(units, CMD_SET_WANTED_MAX_SPEED, {wantedSpeed}, 0)
+	else
+		local speedOpts = GetCmdOpts(alt, ctrl, meta, shift, true)
+		GiveNotifyingOrder(CMD_SET_WANTED_MAX_SPEED, {wantedSpeed / 30}, speedOpts)
+	end
 end
 
 --------------------------------------------------------------------------------
@@ -570,25 +599,7 @@ function widget:MouseRelease(mx, my, mButton)
 			end
 		end
 
-		if CMD_SET_WANTED_MAX_SPEED then  -- Removed in spring 104
-			-- Move Speed (Applicable to every order)
-			local wantedSpeed = 99999 -- High enough to exceed all units speed, but not high enough to cause errors (i.e. vs math.huge)
-			
-			if ctrl then
-				local selUnits = spGetSelectedUnits()
-				for i = 1, #selUnits do
-					local uSpeed = UnitDefs[spGetUnitDefID(selUnits[i])].speed
-					if uSpeed > 0 and uSpeed < wantedSpeed then
-						wantedSpeed = uSpeed
-					end
-				end
-			end
-			
-			-- Directly giving speed order appears to work perfectly, including with shifted orders ...
-			-- ... But other widgets CMD.INSERT the speed order into the front (Posn 1) of the queue instead (which doesn't work with shifted orders)
-			local speedOpts = GetCmdOpts(alt, ctrl, meta, shift, true)
-			GiveNotifyingOrder(CMD_SET_WANTED_MAX_SPEED, {wantedSpeed / 30}, speedOpts)
-		end
+		SendSetWantedMaxSpeed(alt, ctrl, meta, shift)
 	end
 	
 	if #fNodes > 1 then


### PR DESCRIPTION
Only affects spring 104+ engine

It fixs the bizarre "moving" bug. In the same shoot, the units speed matching using Ctrl key is recovered