### PR TITLE
Fix #199

### DIFF
--- a/BaseClasses/Units/Infantry.lua
+++ b/BaseClasses/Units/Infantry.lua
@@ -303,6 +303,7 @@ local ATLauncherInf = Infantry:New{
 	maxVelocity			= 1.5,
 
 	customParams = {
+		fastAim = true,
 		wiki_subclass_comments = [[Is the enemy rushing your base with tanks?
 well, a couple of this guys may appropriately welcome them. Due to the low fire
 range and rate, Anti-Tank Infantry has a very low performance fighting enemy

--- a/scripts/Infantry.lua
+++ b/scripts/Infantry.lua
@@ -92,6 +92,7 @@ local wantedHeading
 local wantedPitch
 local firing
 local lastShot
+local fast_aim = UnitDef.customParams.fastaim
 
 -- OTHER
 local fear
@@ -276,7 +277,25 @@ function PickPose(name)
 	return true
 end
 
+local function FastAim(newHeading, newPitch)
+	local pose = poses[currentPoseID]
+	local headingTurn, pitchTurn = pose.headingTurn, pose.pitchTurn
+	if headingTurn then
+		local p, axis, target, mul = unpack(headingTurn)
+		Turn(p, axis, target + mul * newHeading)
+	end
+	if pitchTurn then
+		local p, axis, target, mul = unpack(pitchTurn)
+		Turn(p, axis, target + mul * newPitch)
+	end
+	currentHeading = newHeading
+	currentPitch = newPitch
+	return true
+end
+
 local function ReAim(newHeading, newPitch)
+	if fast_aim then return FastAim(newHeading, newPitch) end
+
 	--Spring.Echo("reaiming")
 	if currentHeading and currentPitch then
 		local hDiff = currentHeading - newHeading
@@ -748,7 +767,9 @@ function script.AimWeapon(num, heading, pitch)
 	StartThread(Delay, Stand, STAND_DELAY, SIG_RESTORE)
 	wantedHeading = heading
 	wantedPitch = pitch
-	if CanAim(weaponClass) then return ReAim(heading, pitch) end
+	if CanAim(weaponClass) then
+		return ReAim(heading, pitch)
+	end
 	StartAiming(weaponClass)
 	return false
 end


### PR DESCRIPTION
Now `ATLauncherInf` has the custom parameter `fastAim`, which makes them circumvent the aiming process. I dare you play with your BA64s through the enemy lines again...

`ATLauncherInf` guys are however still subjected to the other rules, e.g. they cannot shot if they are changing pose. So vehicles may have some chances if rushing in groups with the barrels well oriented, or assisted by scout planes. But AT infantry is definitively becoming deadly for alone vehicles.