### PR TITLE
Fixed allied teams disputing the same gun

### DIFF
--- a/LuaRules/Gadgets/unit_infgun.lua
+++ b/LuaRules/Gadgets/unit_infgun.lua
@@ -27,6 +27,7 @@ local GetUnitsInSphere      = Spring.GetUnitsInSphere
 local GetUnitTeam           = Spring.GetUnitTeam
 local TransferUnit          = Spring.TransferUnit
 local GetUnitMass           = Spring.GetUnitMass
+local AreTeamsAllied        = Spring.AreTeamsAllied
 
 local infguns = {}
 local infguns_indexes = {}
@@ -98,8 +99,8 @@ function gadget:GameFrame(frame)
         if u ~= unitID then
             local t = GetUnitTeam(u)
             if t ~= GAIA_TEAM_ID and GetUnitMass(u) < 100 then
-                if new_team ~= GAIA_TEAM_ID and new_team ~= t then
-                    -- Several teams disputing the gun, don't do nothing
+                if new_team ~= GAIA_TEAM_ID and new_team ~= t and not AreTeamsAllied(new_team, t) then
+                    -- Several (non-allied) teams disputing the gun, just don't do anything
                     new_team = nil
                     break
                 end

--- a/scripts/InfantryGun.lua
+++ b/scripts/InfantryGun.lua
@@ -82,6 +82,15 @@ local function UpdateCrew()
             Spring.SetUnitNeutral(unitID, true)
         else
             Spring.SetUnitNeutral(unitID, false)
+            local gun_team = Spring.GetUnitTeam(unitID)
+            local pax_team = gun_team
+            for _,paxID in pairs(passengersIDs) do
+                pax_team = Spring.GetUnitTeam(paxID)
+                break
+            end
+            if pax_team ~= gun_team then
+                Spring.TransferUnit(unitID, pax_team)
+            end
             -- Make the unit non-capturable until the crew has not been killed
             Spring.SetUnitHealth(unitID, {capture = 0})
         end


### PR DESCRIPTION
Now when several allied teams are close to the same "abandoned" gun, the gun is assigned to one of them, with a so far arbitrary criteria. It does not matters though, since any other ally can still load infantry in such gun, and the first one loading a soldier is taking control of the gun.

This should fix #430