### PR TITLE
Avoid problems with the temporal github-release-test tag

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -32,7 +32,7 @@ jobs:
       uses: haya14busa/action-cond@v1
       id: VERSION_MAJOR
       with:
-        cond: ${{ steps.last_tag.outputs.last_tag == '' }}
+        cond: ${{ (steps.last_tag.outputs.last_tag == '') || (steps.last_tag.outputs.last_tag == '"github') }}
         if_true: $((${{env.LAST_VERSION_MAJOR}} + 1))
         if_false: $((${{steps.last_tag.outputs.last_tag}} + 1))
 


### PR DESCRIPTION
The temporal tag github-release-test breaks the logic, so a workarund is required