### PR TITLE
Modrules: explicit `allowGroundUnitGravity`

### DIFF
--- a/gamedata/modrules.lua
+++ b/gamedata/modrules.lua
@@ -19,6 +19,7 @@ local modRules = {
 		allowUnitCollisionDamage  = false,
 		allowUnitCollisionOverlap  = false,
 		allowSepAxisCollisionTest = true,
+		allowGroundUnitGravity = true,
 	},
 	nanospray = {
 		allow_team_colours	=	false,


### PR DESCRIPTION
This is already the implicit value, because it's the engine default. So there is no logic change, just safety against engine changes.