### PR TITLE
Replace `CSphereParticleSpawner` with `CSimpleParticleSystem`

### DIFF
--- a/effects/weapon_explosions.lua
+++ b/effects/weapon_explosions.lua
@@ -1472,7 +1472,7 @@ return {
   ["bulletimpact"] = {
     particle_dust1 = {
       air                = true,
-      class              = [[CSphereParticleSpawner]],
+      class              = [[CSimpleParticleSystem]],
       count              = 1,
       ground             = true,
       water              = false,
@@ -1500,7 +1500,7 @@ return {
     },
     particle_dust2 = {
       air                = false,
-      class              = [[CSphereParticleSpawner]],
+      class              = [[CSimpleParticleSystem]],
       count              = 1,
       ground             = true,
       water              = false,


### PR DESCRIPTION
These have always been equivalent in behaviour, but the former will be getting removed in future engines.